### PR TITLE
riscv: dts: allwinner: d1: Enable audio-out pads on MangoPi MQ-Pro

### DIFF
--- a/arch/riscv/boot/dts/allwinner/sun20i-d1-mangopi-mq-pro.dts
+++ b/arch/riscv/boot/dts/allwinner/sun20i-d1-mangopi-mq-pro.dts
@@ -79,6 +79,13 @@
 	cpu-supply = <&reg_vdd_cpu>;
 };
 
+&codec {
+	routing = "Pads", "HPOUTL",
+		"Pads", "HPOUTR";
+	widgets = "Headphone", "Pads";
+	status = "okay";
+};
+
 &de {
 	status = "okay";
 };


### PR DESCRIPTION
Mango Pi MQ-Pro has audio pads on the PCB bottom and they works!

MQ-Pro schematics suggests the HPOUT L/R are used.