### PR TITLE
riscv: dts: allwinner: d1: Enable I2S on MangoPi MQ-Pro

### DIFF
--- a/arch/riscv/boot/dts/allwinner/sun20i-d1-mangopi-mq-pro.dts
+++ b/arch/riscv/boot/dts/allwinner/sun20i-d1-mangopi-mq-pro.dts
@@ -45,6 +45,12 @@
 		};
 	};
 
+	pcm5102a: pcm5102a-codec {
+		compatible = "ti,pcm5102a";
+		status = "okay";
+		#sound-dai-cells = <0>;
+	};
+
 	reg_avdd2v8: avdd2v8 {
 		compatible = "regulator-fixed";
 		regulator-name = "avdd2v8";
@@ -67,6 +73,22 @@
 		regulator-min-microvolt = <1100000>;
 		regulator-max-microvolt = <1100000>;
 		vin-supply = <&reg_vcc>;
+	};
+
+	soc {
+		sound {
+			compatible = "simple-audio-card";
+			simple-audio-card,name = "i2s";
+			simple-audio-card,format = "i2s";
+			simple-audio-card,mclk-fs = <256>;
+			status = "okay";
+			simple-audio-card,cpu {
+				sound-dai = <&i2s2>;
+			};
+			simple-audio-card,codec {
+				sound-dai = <&pcm5102a>;
+			};
+		};
 	};
 
 	wifi_pwrseq: wifi-pwrseq {
@@ -98,6 +120,12 @@
 };
 
 &hdmi_phy {
+	status = "okay";
+};
+
+&i2s2 {
+	pinctrl-0 = <&i2s2_pb567_pins>, <&i2s2_pb3_din_pin>, <&i2s2_pb4_dout_pin>;
+	pinctrl-names = "default";
 	status = "okay";
 };
 

--- a/arch/riscv/boot/dts/allwinner/sun20i-d1.dtsi
+++ b/arch/riscv/boot/dts/allwinner/sun20i-d1.dtsi
@@ -159,6 +159,24 @@
 			};
 
 			/omit-if-no-ref/
+			i2s2_pb567_pins: i2s2-pb567-pins {
+				pins = "PB5", "PB6", "PB7";
+				function = "i2s2";
+			};
+
+			/omit-if-no-ref/
+			i2s2_pb3_din_pin: i2s2-pb3-din-pin {
+				pins = "PB3";
+				function = "i2s2_din";
+			};
+
+			/omit-if-no-ref/
+			i2s2_pb4_dout_pin: i2s2-pb4-dout-pin {
+				pins = "PB4";
+				function = "i2s2_dout";
+			};
+
+			/omit-if-no-ref/
 			lcd_rgb666_pins: lcd-rgb666-pins {
 				pins = "PD0", "PD1", "PD2", "PD3", "PD4", "PD5",
 				       "PD6", "PD7", "PD8", "PD9", "PD10", "PD11",


### PR DESCRIPTION
1. Restore I2S2 pin control.
2. Enable I2S and hardcode (very popular) PCM5102A codec to create simple-audio-card.

(2) could be bad idea in main DT. Please let me know if this requires rework, perhaps externalizing into an overlay.